### PR TITLE
add LEVELUP_CHANNEL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ OUTCOME_CHANNEL=the channel id where the outcome of the applications will be sen
 APPLICATIONS_CHANNEL=the channel id where people apply
 GUIDE_CHANNEL=the channel id where the guide message is
 GUIDE_MESSAGE=the message id of the guide
+LEVELUP_CHANNEL=the channel id where level up messages will be sent to


### PR DESCRIPTION
Previously, `process.env.LEVELUP_CHANNEL`, which was used in `levelmanager.ts` was not present in `.env.example`. This means that when you create the `.env` file, the channel ID would be undefined. This may have happened as a result of creating the leveling system without updating the `.env.example` file.