### PR TITLE
/apply: allow user to not require https:// included in the URL

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -299,7 +299,7 @@ export default {
             }
 
             const role = interaction.options.getString("role", true);
-            const proof = interaction.options.getString("proof", true);
+            let proof = interaction.options.getString("proof", true); // is this allowed?
             let canParseProof = URL.canParse(proof);
             
             // check if proof is valid but is missing https

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -315,7 +315,7 @@ export default {
             }
 
             // verify the proof is a valid url
-            if (canParseProof) {
+            if (!canParseProof) {
                 await interaction.editReply("Invalid proof URL.");
                 return;
             }

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -300,7 +300,7 @@ export default {
 
             const role = interaction.options.getString("role", true);
             const proof = interaction.options.getString("proof", true);
-            const canParseProof = URL.canParse(proof);
+            let canParseProof = URL.canParse(proof);
             
             // check if proof is valid but is missing https
             if (!canParseProof && URL.canParse("https://" + proof)) {

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -300,7 +300,14 @@ export default {
 
             const role = interaction.options.getString("role", true);
             const proof = interaction.options.getString("proof", true);
-
+            const canParseProof = URL.canParse(proof);
+            
+            // check if proof is valid but is missing https
+            if (!canParseProof && URL.canParse("https://" + proof)) {
+                proof = "https://" + proof; // make sure user cannot avoid duplicate system by removing/adding https
+                canParseProof = true;
+            }            
+            
             // check if the proof has been submitted before and not by the same user
             if (db.query(`SELECT * FROM proofs WHERE proof = $proof AND userid != '${interaction.user.id}'`).get({ $proof: proof })) {
                 await interaction.editReply("This proof has already been used before by someone else.");
@@ -308,8 +315,8 @@ export default {
             }
 
             // verify the proof is a valid url
-            if (!URL.canParse(proof)) {
-                await interaction.editReply("Invalid proof URL. (did you forget https://?)");
+            if (canParseProof) {
+                await interaction.editReply("Invalid proof URL.");
                 return;
             }
             const proofURL = new URL(proof);


### PR DESCRIPTION
Some changes in `apply.ts` *should* make it so that they are not required to add https:// to the URL, and will fix the URL for them if it is left out. I haven't used JavaScript or TypeScript in a while but it should work.
**Changes:**
- Make `URL.canParse(proof)` a variable(`canParseProof`) to avoid redundancy
- Check if `"https://" + proof` is a valid URL, and if so, change `proof` to said value and `canParseProof` to `true`
- Changed invalid URL message to not include the part about https://, can be reverted

Feel free to make any changes to `apply.ts` if I made any mistakes.