### PR TITLE
Fix invalid page limit bug

### DIFF
--- a/src/dashboard/api-common.ts
+++ b/src/dashboard/api-common.ts
@@ -1,0 +1,11 @@
+import { Database } from "bun:sqlite";
+
+function IGetMaxCommentsPage(packid: string, db: Database, pageSize: number) {
+    const comments =
+        db.query<{ row_count: number }, [string]>(`SELECT COUNT(*) AS row_count FROM pack_comments WHERE packid = ?`).get(packid)
+            ?.row_count ?? 0;
+
+    return Math.ceil(Math.max(comments, 1) / pageSize);
+}
+
+export { IGetMaxCommentsPage };

--- a/src/dashboard/api-test.ts
+++ b/src/dashboard/api-test.ts
@@ -12,6 +12,7 @@ import { Database } from "bun:sqlite";
 import config from "../config";
 import webpush from "web-push";
 import packData from "./data.json";
+import { IGetMaxCommentsPage } from "./api-common";
 
 // set up test database
 const db = new Database(":memory:");
@@ -166,7 +167,7 @@ export default class DashboardAPITest implements DashboardAPIInterface {
     }
 
     async FetchPackComments(packid: string, page: number) {
-        if (page >= 10) {
+        if (page >= this.GetMaxCommentsPage(packid)) {
             return null;
         }
 
@@ -254,11 +255,7 @@ export default class DashboardAPITest implements DashboardAPIInterface {
         db.run("DELETE FROM push_subscriptions WHERE userid = ? AND endpoint = ?", [userid, endpoint]);
     }
 
-    async GetMaxCommentsPage(packid: string) {
-        const comments =
-            db.query<{ row_count: number }, [string]>(`SELECT COUNT(*) AS row_count FROM pack_comments WHERE packid = ?`).get(packid)
-                ?.row_count ?? 0;
-
-        return Math.ceil(Math.max(comments, 1) / CommentsPageSize);
+    GetMaxCommentsPage(packid: string) {
+        return IGetMaxCommentsPage(packid, db, CommentsPageSize);
     }
 }

--- a/src/dashboard/api-types.ts
+++ b/src/dashboard/api-types.ts
@@ -12,7 +12,7 @@ interface DashboardAPIInterface {
     RegisterPushSubscription: (userid: string, subscription: PushSubscriptionData) => void;
     UnregisterPushSubscription: (userid: string, endpoint: string) => void;
     SendPushNotification: (userid: string, notification: NotificationData) => void;
-    GetMaxCommentsPage: (packid: string) => Promise<number>;
+    GetMaxCommentsPage: (packid: string) => number;
 }
 
 interface PushSubscriptionData {


### PR DESCRIPTION
Unify GetMaxCommentsPage
Add preemptive packid sanitization

### Description

Fix a hard pack comments page limit in the dev API.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


### Additional Information

Also includes preemptive packid sanitisation in the /api/comments GET route.
